### PR TITLE
Fix security hole in /boot

### DIFF
--- a/ada/disko/disk.nix
+++ b/ada/disko/disk.nix
@@ -17,8 +17,8 @@
                   format = "vfat";
                   mountpoint = "/boot";
                   mountOptions = [
-                    "fmask=0022"
-                    "dmask=0022"
+                    "fmask=0077"
+                    "dmask=0077"
                   ];
                 };
               };

--- a/isla/disko/disk.nix
+++ b/isla/disko/disk.nix
@@ -17,8 +17,8 @@ _: {
                   format = "vfat";
                   mountpoint = "/boot";
                   mountOptions = [
-                    "fmask=0022"
-                    "dmask=0022"
+                    "fmask=0077"
+                    "dmask=0077"
                   ];
                 };
               };

--- a/viola/disko/disk.nix
+++ b/viola/disko/disk.nix
@@ -17,8 +17,8 @@
                   format = "vfat";
                   mountpoint = "/boot";
                   mountOptions = [
-                    "fmask=0022"
-                    "dmask=0022"
+                    "fmask=0077"
+                    "dmask=0077"
                   ];
                 };
               };


### PR DESCRIPTION
Fixed "Mount point '/boot' which backs the random seed file is world accessible, which is a security hole!" by change mount option mask